### PR TITLE
Add API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,11 +7,11 @@ gem "spree_auth_devise", "~> 3.1.0"
 gem "spree", "~> 3.1.0"
 
 group :development, :test do
-  gem "fuubar"
   gem "pry"
 end
 
 group :test do
+  gem 'rspec-rails', '~> 3.5'
   gem "shoulda-matchers"
   gem "rspec-activemodel-mocks"
   gem "rspec-its"

--- a/app/controllers/spree/api/v1/add_ons_controller.rb
+++ b/app/controllers/spree/api/v1/add_ons_controller.rb
@@ -1,0 +1,80 @@
+module Spree
+  module Api
+    module V1
+      class AddOnsController < Spree::Api::BaseController
+        include Spree::PermittedAttributes
+        before_action :find_product,
+                      if: proc { params[:product_id].present? }
+        before_action :add_on, only: [:show, :update, :destroy]
+
+        def index
+          @add_ons = @product.add_ons.
+                     accessible_by(current_ability, :read).
+                     page(params[:page]).per(params[:per_page])
+          respond_with(@add_ons)
+        end
+
+        def show
+          respond_with(@add_on)
+        end
+
+        def new
+        end
+
+        # rubocop:disable Metrics/MethodLength
+        def create
+          authorize! :create, AddOn
+          @add_on = @product.add_ons.new(add_on_params)
+          if @add_on.save
+            respond_with(@add_on, status: 201, default_template: :show)
+          else
+            invalid_resource!(@add_on)
+          end
+        end
+
+        def update
+          if @add_on
+            authorize! :update, @add_on
+            @add_on.update_attributes(add_on_params)
+            respond_with(@add_on, status: 200, default_template: :show)
+          else
+            invalid_resource!(@add_on)
+          end
+        end
+
+        def destroy
+          if @add_on
+            authorize! :destroy, @add_on
+            @add_on.destroy
+            respond_with(@add_on, status: 204)
+          else
+            invalid_resource!(@add_on)
+          end
+        end
+        # rubocop:enable Metrics/MethodLength
+
+        private
+
+        def find_product
+          @product = super(params[:product_id])
+          authorize! :read, @product
+        end
+
+        # rubocop:disable Metrics/MethodLength
+        def add_on
+          if @product
+            @add_on ||= @product.add_ons.find_by(id: params[:id])
+          else
+            @add_on = Spree::AddOn.find(params[:id])
+          end
+          authorize! :read, @add_on
+        end
+        # rubocop:enable Metrics/MethodLength
+
+        def add_on_params
+          params.require(:add_on).permit(@@add_on_attributes)
+        end
+      end
+    end
+  end
+end

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,5 +1,6 @@
 module Spree
   Product.class_eval do
     has_many :add_ons, dependent: :destroy
+    accepts_nested_attributes_for :add_ons, allow_destroy: true
   end
 end

--- a/app/views/spree/api/v1/add_ons/index.rabl
+++ b/app/views/spree/api/v1/add_ons/index.rabl
@@ -1,0 +1,11 @@
+object false
+child(@add_ons => :add_ons) do
+  attributes(:id, :product_id, :name, :description, :display_amount)
+
+  child(prices: :prices) do
+    attributes(:id, :amount)
+  end
+end
+node(:count) { @add_ons.count }
+node(:current_page) { params[:page] || 1 }
+node(:pages) { @add_ons.total_pages }

--- a/app/views/spree/api/v1/add_ons/new.rabl
+++ b/app/views/spree/api/v1/add_ons/new.rabl
@@ -1,0 +1,7 @@
+node(:attributes) do
+  [
+    :description, :name, :type, :default, :expiration_days,
+    prices_attributes: [:amount]
+  ]
+end
+node(:required_attributes) { [] }

--- a/app/views/spree/api/v1/add_ons/show.rabl
+++ b/app/views/spree/api/v1/add_ons/show.rabl
@@ -1,0 +1,2 @@
+object @add_on
+attributes(:id, :product_id, :name, :description, :display_amount)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,13 @@
 Spree::Core::Engine.routes.draw do
+  namespace :api, defaults: { format: 'json' } do
+    namespace :v1 do
+      resources :products do
+        resources :add_ons
+      end
+      resources :add_ons
+    end
+  end
+
   namespace :admin do
     resources :products do
       resources :add_ons

--- a/spec/controllers/api/v1/add_ons_controller_spec.rb
+++ b/spec/controllers/api/v1/add_ons_controller_spec.rb
@@ -1,0 +1,150 @@
+require "spec_helper"
+# rubocop:disable Metrics/ModuleLength
+module Spree
+  describe Api::V1::AddOnsController, type: :controller do
+    render_views
+
+    let!(:product) { create(:product) }
+    let!(:add_on_1) do
+      product.add_ons.create(
+        name: "Inscription",
+        description: "my value 1",
+        default: false,
+        prices_attributes: [
+          amount: 9.99
+        ]
+      )
+    end
+    let!(:add_on_2) do
+      product.add_ons.create(
+        name: "Inscription 2",
+        description: "my value 2",
+        default: false,
+        prices_attributes: [
+          amount: 9.49
+        ]
+      )
+    end
+    let(:new_attributes) do
+      [
+        "description", "name", "type", "default", "expiration_days",
+        "prices_attributes" => ["amount"]
+      ]
+    end
+    let(:attributes) do
+      [
+        :id, :product_id, :name, :description, :display_amount
+      ]
+    end
+    let(:resource_scoping) { { product_id: product.to_param } }
+    before do
+      stub_authentication!
+    end
+
+    context "if product is deleted" do
+      before do
+        product.update_column(:deleted_at, 1.day.ago)
+      end
+
+      it "can not see a list of product add_ons" do
+        api_get :index
+        expect(response.status).to eq(404)
+      end
+    end
+
+    it "cannot create a new product add_on if not an admin" do
+      api_post :create, add_on: { name: "My Add On 3" }
+      assert_unauthorized!
+    end
+
+    it "cannot update a product add_on" do
+      api_put :update, id: add_on_1.name, add_on: { value: "my value 456" }
+      assert_unauthorized!
+    end
+
+    it "cannot delete a product add_on" do
+      api_delete :destroy, id: add_on_1.to_param, name: add_on_1.name
+      assert_unauthorized!
+      expect { add_on_1.reload }.not_to raise_error
+    end
+
+    context "as an admin" do
+      let(:current_api_user) do
+        user = Spree.user_class.
+               new(email: "spree@example.com", password: "password")
+        user.generate_spree_api_key!
+        user
+      end
+      before do
+        allow(current_api_user).to receive(:has_spree_role?) { true }
+      end
+
+      it "can see a list of all product add_ons" do
+        api_get :index
+        expect(json_response["add_ons"].count).to eq 2
+        expect(json_response["add_ons"].first).to include(*attributes)
+      end
+
+      it "can learn how to create a new product add_on" do
+        api_get :new
+        expect(json_response["attributes"]).to eq(new_attributes)
+        expect(json_response["required_attributes"]).to be_empty
+      end
+
+      it "can control the page size through a parameter" do
+        api_get :index, per_page: 1
+        expect(json_response["add_ons"].count).to eq(1)
+        expect(json_response["current_page"]).to eq(1)
+        expect(json_response["pages"]).to eq(2)
+      end
+
+      it "can see a single add_on" do
+        api_get :show, id: add_on_1.id
+        expect(json_response).to include(*attributes)
+      end
+
+      it "can create a new product add_on" do
+        expect do
+          api_post(
+            :create,
+            add_on: {
+              name: "My Add On 3", prices_attributes: [amount: 9.99]
+            }
+          )
+        end.to change(product.add_ons, :count).by(1)
+        expect(json_response).to include(*attributes)
+        expect(response.status).to eq(201)
+      end
+
+      it "can update a product add_on" do
+        api_put(
+          :update,
+          id: add_on_1.id,
+          add_on: { prices_attributes: [amount: 99.99] }
+        )
+        expect(response.status).to eq(200)
+      end
+
+      it "can delete a product add_on" do
+        api_delete :destroy, id: add_on_1.id
+        expect(response.status).to eq(204)
+        expect { add_on_1.reload }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+
+      context "with product identified by id" do
+        let(:resource_scoping) { { product_id: product.id } }
+        it "can see a list of all product add_ons" do
+          api_get :index
+          expect(json_response["add_ons"].count).to eq 2
+          expect(json_response["add_ons"].first).to include(*attributes)
+        end
+
+        it "can see a single add_on by id" do
+          api_get :show, id: add_on_1.id
+          expect(json_response).to include(*attributes)
+        end
+      end
+    end
+  end
+end
+# rubocop:enable Metrics/ModuleLength

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,17 +25,28 @@ require "shoulda/matchers"
 Dir[File.join(File.dirname(__FILE__), "support/**/*.rb")].each { |f| require f }
 
 # Requires factories defined in spree_core
-require "spree/testing_support/factories"
 require "spree/testing_support/controller_requests"
 require "spree/testing_support/authorization_helpers"
 require "spree/testing_support/url_helpers"
+require "spree/testing_support/factories"
+require "spree/testing_support/preferences"
 
+require "spree/api/testing_support/caching"
+require "spree/api/testing_support/helpers"
+require "spree/api/testing_support/setup"
 # Find any extension definitions.
 FactoryGirl.find_definitions
 
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
+  config.include Spree::Api::TestingSupport::Helpers, type: :controller
+  config.extend Spree::Api::TestingSupport::Setup, type: :controller
+  config.include Spree::TestingSupport::Preferences, type: :controller
   config.infer_spec_type_from_file_location!
+  config.before do
+    Spree::Api::Config[:requires_authentication] = true
+  end
+
   # == URL Helpers
   #
   # Allows access to Spree"s routes in specs:
@@ -54,7 +65,7 @@ RSpec.configure do |config|
   config.mock_with :rspec
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_path = "#{::Rails.root}/spec/fixtures"
+  # config.fixture_path = "#{::Rails.root}/spec/fixtures"
 
   # Capybara javascript drivers require transactional fixtures set to false,
   # and we use DatabaseCleaner to cleanup after each test instead.  Without

--- a/spec/support/controller_hacks.rb
+++ b/spec/support/controller_hacks.rb
@@ -1,0 +1,33 @@
+require 'active_support/all'
+module ControllerHacks
+  extend ActiveSupport::Concern
+
+  included do
+    routes { Spree::Core::Engine.routes }
+  end
+
+  def api_get(action, params={}, session=nil, flash=nil)
+    api_process(action, params, session, flash, "GET")
+  end
+
+  def api_post(action, params={}, session=nil, flash=nil)
+    api_process(action, params, session, flash, "POST")
+  end
+
+  def api_put(action, params={}, session=nil, flash=nil)
+    api_process(action, params, session, flash, "PUT")
+  end
+
+  def api_delete(action, params={}, session=nil, flash=nil)
+    api_process(action, params, session, flash, "DELETE")
+  end
+
+  def api_process(action, params={}, session=nil, flash=nil, method="get")
+    scoping = respond_to?(:resource_scoping) ? resource_scoping : {}
+    process(action, method, params.merge(scoping).reverse_merge!(format: :json), session, flash)
+  end
+end
+
+RSpec.configure do |config|
+  config.include ControllerHacks, type: :controller
+end


### PR DESCRIPTION
- add an api that functions like existing spree apis
- see http://guides.spreecommerce.org/api/ for existing spree api
  documentation
